### PR TITLE
feat: add HPA support to app chart

### DIFF
--- a/charts/app/templates/hpa.yaml
+++ b/charts/app/templates/hpa.yaml
@@ -1,0 +1,49 @@
+{{- range $componentName, $component := .Values.components }}
+{{- if ne ($component.enabled | default true) false }}
+{{- if $component.hpa }}
+{{- if $component.hpa.enabled }}
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "app.componentFullname" (dict "releaseName" $.Release.Name "componentName" $componentName) }}
+  labels:
+    {{- include "app.componentLabels" (dict "root" $ "componentName" $componentName) | nindent 4 }}
+    {{- with include "app.customLabels" (dict "global" $.Values.global "component" $component) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "app.componentFullname" (dict "releaseName" $.Release.Name "componentName" $componentName) }}
+  minReplicas: {{ $component.hpa.minReplicas | default 1 }}
+  maxReplicas: {{ $component.hpa.maxReplicas | default 10 }}
+  metrics:
+    {{- if $component.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ $component.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if $component.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ $component.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- if $component.hpa.customMetrics }}
+    {{- toYaml $component.hpa.customMetrics | nindent 4 }}
+    {{- end }}
+  {{- if $component.hpa.behavior }}
+  behavior:
+    {{- toYaml $component.hpa.behavior | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -145,6 +145,14 @@ global:
 #       affinity:                    # overrides global affinity
 #         podAntiAffinity:
 #           requiredSpreadBy: ["kubernetes.io/hostname"]
+#       hpa:                         # horizontal pod autoscaler
+#         enabled: false
+#         minReplicas: 2
+#         maxReplicas: 10
+#         targetCPUUtilizationPercentage: 80
+#         targetMemoryUtilizationPercentage: 80
+#         customMetrics: []
+#         behavior: {}
 #       initContainers: []
 #       additionalContainers: []
 #

--- a/tests/app/values-full.yaml
+++ b/tests/app/values-full.yaml
@@ -78,6 +78,11 @@ components:
     affinity:
       podAntiAffinity:
         requiredSpreadBy: ["topology.kubernetes.io/zone"]
+    hpa:
+      enabled: true
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
     initContainers:
       - name: wait-for-db
         image: "busybox:latest"
@@ -114,6 +119,12 @@ components:
     affinity:
       podAntiAffinity:
         avoidComponents: ["web"]
+    hpa:
+      enabled: true
+      minReplicas: 3
+      maxReplicas: 20
+      targetCPUUtilizationPercentage: 80
+      targetMemoryUtilizationPercentage: 75
 
   scheduler:
     enabled: true


### PR DESCRIPTION
Adds Horizontal Pod Autoscaler (HPA) support to the app chart.

## Changes
- Add hpa.yaml template with autoscaling/v2 HPA
- Support per-component HPA configuration
- Include CPU and memory utilization targets
- Support custom metrics and scaling behavior
- Add HPA examples to test values

Resolves #39

Generated with [Claude Code](https://claude.ai/code)