### PR TITLE
feat(app): Replace server-snippet with standalone blocking Ingress

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 description: Helm Chart for multi-component application deployments
 name: app
-version: 1.1.0
+version: 1.2.0
 appVersion: "1.0.0"

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -266,6 +266,32 @@ Usage: {{ include "app.affinity.podAnti" (dict "root" $ "componentName" $name "c
 {{- end }}
 
 {{/*
+Resolve securityPathFilter - component-level overrides global
+Usage: {{ include "app.securityPathFilter" (dict "component" $component "global" $.Values.global) }}
+Returns the resolved securityPathFilter config as YAML, or empty string if disabled/not set.
+*/}}
+{{- define "app.securityPathFilter" -}}
+{{- $filter := dict }}
+{{- if .global.securityPathFilter }}
+{{- $filter = .global.securityPathFilter }}
+{{- end }}
+{{- if .component.ingress }}
+{{- if hasKey .component.ingress "securityPathFilter" }}
+{{- if .component.ingress.securityPathFilter }}
+{{- $filter = .component.ingress.securityPathFilter }}
+{{- else }}
+{{- $filter = dict }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and $filter (kindIs "map" $filter) }}
+{{- if $filter.enabled }}
+{{- toYaml $filter }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Pod affinity builder
 Usage: {{ include "app.affinity.pod" (dict "root" $ "componentName" $name "config" $config) }}
 */}}

--- a/charts/app/templates/ingress-security-block.yaml
+++ b/charts/app/templates/ingress-security-block.yaml
@@ -1,0 +1,58 @@
+{{- range $componentName, $component := .Values.components }}
+{{- if ne ($component.enabled | default true) false }}
+{{- if $component.ingress }}
+{{- if $component.ingress.enabled }}
+{{- $resolved := include "app.securityPathFilter" (dict "component" $component "global" $.Values.global) }}
+{{- if $resolved }}
+{{- $filter := $resolved | fromYaml }}
+{{- $ingressHost := $component.ingress.host | default $.Values.global.host }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "app.componentFullname" (dict "releaseName" $.Release.Name "componentName" $componentName) }}-security-block
+  labels:
+    {{- include "app.componentLabels" (dict "root" $ "componentName" $componentName) | nindent 4 }}
+    {{- with include "app.customLabels" (dict "global" $.Values.global "component" $component) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  {{- $tlsEnabled := true }}
+  {{- if $component.ingress.tls }}
+  {{- if kindIs "bool" $component.ingress.tls.enabled }}
+  {{- $tlsEnabled = $component.ingress.tls.enabled }}
+  {{- end }}
+  {{- end }}
+  {{- if $tlsEnabled }}
+  tls:
+    - hosts:
+        - {{ $ingressHost }}
+      {{- $customSecretName := "" }}
+      {{- if $component.ingress.tls }}
+      {{- $customSecretName = $component.ingress.tls.secretName }}
+      {{- end }}
+      {{- if $customSecretName }}
+      secretName: {{ $customSecretName }}
+      {{- else }}
+      secretName: {{ include "app.componentFullname" (dict "releaseName" $.Release.Name "componentName" $componentName) }}-tls
+      {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ $ingressHost }}
+      http:
+        paths:
+          {{- range $filter.blockedPaths }}
+          - path: {{ . }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "app.componentFullname" (dict "releaseName" $.Release.Name "componentName" $componentName) }}-security-block
+                port:
+                  number: 80
+          {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -46,25 +46,6 @@ metadata:
     {{- /* IP Whitelist for VPN restriction */}}
     {{- if $component.ingress.whitelistSourceRange }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ $component.ingress.whitelistSourceRange | quote }}
-    {{- /* Allow ACME challenge to bypass whitelist when TLS is enabled */}}
-    {{- if $tlsEnabled }}
-    nginx.ingress.kubernetes.io/configuration-snippet: |
-      location /.well-known/acme-challenge/ {
-        allow all;
-      }
-    {{- end }}
-    {{- end }}
-    {{- /* Security path filter via server-snippet */}}
-    {{- if $component.ingress.securityPathFilter }}
-    {{- if $component.ingress.securityPathFilter.enabled }}
-    nginx.ingress.kubernetes.io/server-snippet: |
-      {{- range $component.ingress.securityPathFilter.blockedPaths }}
-      location ~* ^{{ . }} {
-          deny all;
-          return 404;
-      }
-      {{- end }}
-    {{- end }}
     {{- end }}
 spec:
   ingressClassName: nginx


### PR DESCRIPTION
NGINX Ingress controller disables snippet annotations (allow-snippet-annotations: false), which prevents deploy. Replace server-snippet and configuration-snippet with a separate Ingress resource that routes blocked paths to a non-existent service, returning 404.