### PR TITLE
feat(app): Add Traefik IP allowlist middleware for whitelistSourceRange

### DIFF
--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 description: Helm Chart for multi-component application deployments
 name: app
-version: 1.3.0
+version: 1.4.0
 appVersion: "1.0.0"

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -292,6 +292,16 @@ Returns the resolved securityPathFilter config as YAML, or empty string if disab
 {{- end }}
 
 {{/*
+Check if ingress class is traefik
+Usage: {{ include "app.isTraefik" (dict "className" $component.ingress.className "globalClassName" $.Values.global.ingressClassName) }}
+Returns "true" if traefik, empty string otherwise.
+*/}}
+{{- define "app.isTraefik" -}}
+{{- $className := .className | default .globalClassName | default "nginx" -}}
+{{- if eq $className "traefik" -}}true{{- end -}}
+{{- end -}}
+
+{{/*
 Pod affinity builder
 Usage: {{ include "app.affinity.pod" (dict "root" $ "componentName" $name "config" $config) }}
 */}}

--- a/charts/app/templates/ingress.yaml
+++ b/charts/app/templates/ingress.yaml
@@ -45,7 +45,12 @@ metadata:
     {{- end }}
     {{- /* IP Whitelist for VPN restriction */}}
     {{- if $component.ingress.whitelistSourceRange }}
+    {{- $isTraefik := include "app.isTraefik" (dict "className" $component.ingress.className "globalClassName" $.Values.global.ingressClassName) }}
+    {{- if $isTraefik }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $.Release.Namespace }}-{{ include "app.componentFullname" (dict "releaseName" $.Release.Name "componentName" $componentName) }}-ip-allowlist@kubernetescrd
+    {{- else }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ $component.ingress.whitelistSourceRange | quote }}
+    {{- end }}
     {{- end }}
 spec:
   ingressClassName: {{ $component.ingress.className | default $.Values.global.ingressClassName | default "nginx" }}

--- a/charts/app/templates/middleware-ip-allowlist.yaml
+++ b/charts/app/templates/middleware-ip-allowlist.yaml
@@ -1,0 +1,29 @@
+{{- range $componentName, $component := .Values.components }}
+{{- if ne ($component.enabled | default true) false }}
+{{- if $component.ingress }}
+{{- if $component.ingress.enabled }}
+{{- if $component.ingress.whitelistSourceRange }}
+{{- $isTraefik := include "app.isTraefik" (dict "className" $component.ingress.className "globalClassName" $.Values.global.ingressClassName) }}
+{{- if $isTraefik }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ include "app.componentFullname" (dict "releaseName" $.Release.Name "componentName" $componentName) }}-ip-allowlist
+  labels:
+    {{- include "app.componentLabels" (dict "root" $ "componentName" $componentName) | nindent 4 }}
+    {{- with include "app.customLabels" (dict "global" $.Values.global "component" $component) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+spec:
+  ipAllowList:
+    sourceRange:
+      {{- range splitList "," $component.ingress.whitelistSourceRange }}
+      - {{ trim . | quote }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/tests/app/values-full.yaml
+++ b/tests/app/values-full.yaml
@@ -121,6 +121,17 @@ components:
     replicas: 1
     command: "php artisan schedule:work"
 
+  traefik-web:
+    enabled: true
+    image: "myapp-web:v1.0.0"
+    replicas: 2
+    containerPort: 80
+    ingress:
+      enabled: true
+      host: "traefik-app.example.com"
+      className: traefik
+      whitelistSourceRange: "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+
 jobs:
   - name: db-migrate
     image: "myapp-web:v1.0.0"


### PR DESCRIPTION
When using Traefik as ingress controller, whitelistSourceRange now creates a Traefik Middleware CRD (ipAllowList) instead of the nginx-only annotation. The ingress references the middleware via router.middlewares annotation.