### PR TITLE
feat(app): add global timezone configuration for CronJobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ global:
   image: "myapp:v1"           # default for all components/jobs
   host: "app.example.com"     # default host for ingress
   ingressClassName: nginx      # default ingress class (e.g. nginx, traefik)
+  timezone: "Europe/Prague"    # timezone for CronJobs (IANA tz database)
   imagePullPolicy: Always
   envFromSecret: app-secrets
   useDatabaseCert: false

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 description: Helm Chart for multi-component application deployments
 name: app
-version: 1.6.0
+version: 1.7.0
 appVersion: "1.0.0"

--- a/charts/app/templates/cronjobs.yaml
+++ b/charts/app/templates/cronjobs.yaml
@@ -12,6 +12,10 @@ metadata:
     {{- end }}
 spec:
   schedule: {{ required "cronJobs[].schedule is required" .schedule | quote }}
+  {{- $timezone := .timezone | default $.Values.global.timezone }}
+  {{- if $timezone }}
+  timeZone: {{ $timezone | quote }}
+  {{- end }}
   concurrencyPolicy: {{ .concurrencyPolicy | default "Forbid" }}
   jobTemplate:
     spec:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -33,6 +33,10 @@ global:
     mountPath: "/etc/ssl/certs"
     secretName: "database-cert"
 
+  # Timezone for CronJobs (e.g. "Europe/Prague", "UTC")
+  # See: https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#time-zones
+  timezone: null
+
   # Restart all pods on every deployment (adds random annotation)
   restartAfterRedeploy: false
 
@@ -202,6 +206,7 @@ jobs: []
 #       restartPolicy: OnFailure
 #       backoffLimit: 3
 #       concurrencyPolicy: Forbid
+#       timezone: "UTC"                # override global.timezone
 #       resources:
 #         requests:
 #           cpu: "50m"

--- a/tests/app/values-full.yaml
+++ b/tests/app/values-full.yaml
@@ -2,6 +2,7 @@
 # Full test values for app chart demonstrating all features
 
 global:
+  timezone: "Europe/Prague"
   imagePullPolicy: Always
   envFromSecret: app-secrets
   useDatabaseCert: true


### PR DESCRIPTION
Adds global.timezone setting so CronJobs run at the correct local time. Each cronJob can also override it with its own timezone field.