### PR TITLE
feat(app): add PersistentVolume and PersistentVolumeClaim support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ template-app-affinity:
 	rm -rf .build/app
 	helm template test-app-affinity charts/app --output-dir=.build -f tests/app/values-affinity.yaml --debug
 
+template-app-persistence:
+	rm -rf .build/app
+	helm template test-app-persistence charts/app --output-dir=.build -f tests/app/values-persistence.yaml --debug
+
 template-metabase:
 	rm -rf .build/metabase
 	helm template test-metabase charts/metabase --output-dir=.build --debug
@@ -43,6 +47,7 @@ helm-template:
 	make template-stable-app
 	make template-app
 	make template-app-affinity
+	make template-app-persistence
 	make template-metabase
 	make template-adminer
 	make template-rbac

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 description: Helm Chart for multi-component application deployments
 name: app
-version: 1.7.0
+version: 1.8.0
 appVersion: "1.0.0"

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -293,6 +293,154 @@ components:
 
 See [values-affinity.yaml](../../tests/app/values-affinity.yaml) for comprehensive examples.
 
+### Persistence (PersistentVolumes & PersistentVolumeClaims)
+
+The chart supports three complementary ways to use persistent storage:
+
+1. **Per-component PVC (auto-created)** — the common case. Component gets its own PVC dynamically provisioned by a `StorageClass`.
+2. **Chart-level shared PVC** — one PVC referenced by multiple components (typically `ReadWriteMany`).
+3. **Chart-level static PV** — cluster-scoped `PersistentVolume` for pre-provisioned storage (NFS, hostPath, CSI handle).
+
+Volumes are automatically mounted into main container, initContainers, and additionalContainers.
+
+#### Per-component persistence (auto-created PVC)
+
+```yaml
+components:
+  web:
+    persistence:
+      - name: cache             # PVC name: {release}-{component}-cache
+        size: 5Gi
+        accessModes: [ReadWriteOnce]
+        storageClassName: gp3
+        mountPath: /var/cache
+```
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `persistence[].name` | Volume name (also used to derive PVC name) | Required |
+| `persistence[].mountPath` | Container mount path | Required |
+| `persistence[].size` | Requested storage size | Required (unless `existingClaim`) |
+| `persistence[].accessModes` | Access modes | `[ReadWriteOnce]` |
+| `persistence[].storageClassName` | StorageClass to use | Cluster default |
+| `persistence[].subPath` | Mount a subpath | `""` |
+| `persistence[].readOnly` | Mount read-only | `false` |
+| `persistence[].existingClaim` | Reference an existing PVC (skips creation) | `null` |
+| `persistence[].volumeName` | Bind to a specific PV | `null` |
+| `persistence[].labels` / `.annotations` | Extra metadata on the created PVC | `{}` |
+
+#### Shared PVC between components
+
+```yaml
+persistentVolumeClaims:
+  - name: shared-uploads
+    size: 20Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: efs-sc
+
+components:
+  web:
+    persistence:
+      - name: uploads
+        existingClaim: shared-uploads
+        mountPath: /var/www/uploads
+  worker:
+    persistence:
+      - name: uploads
+        existingClaim: shared-uploads
+        mountPath: /var/www/uploads
+```
+
+#### Static PersistentVolume (NFS / hostPath / CSI)
+
+```yaml
+persistentVolumes:
+  - name: shared-nfs
+    capacity: 100Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: ""
+    reclaimPolicy: Retain
+    nfs:
+      server: nfs.example.com
+      path: /exports/shared
+
+persistentVolumeClaims:
+  - name: nfs-claim
+    size: 100Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: ""
+    volumeName: shared-nfs        # bind explicitly to the PV above
+```
+
+Supported source shortcuts on `persistentVolumes[]`: `nfs`, `hostPath`, `csi`, `local`. For any other source type use `source:` and provide raw K8s YAML.
+
+#### DigitalOcean Kubernetes (DOKS)
+
+DO Block Storage (`do-block-storage`) is **ReadWriteOnce only** — a volume is attached to exactly one node at a time. Plan accordingly:
+
+**Per-component private storage** (works out of the box):
+
+```yaml
+components:
+  web:
+    replicas: 1               # RWO: cannot scale replicas on the same PVC
+    strategy:
+      type: Recreate          # avoid attach conflicts on rolling updates
+    persistence:
+      - name: data
+        size: 10Gi
+        accessModes: [ReadWriteOnce]
+        storageClassName: do-block-storage
+        mountPath: /data
+```
+
+Notes:
+- Rolling updates with `ReadWriteOnce` can deadlock on volume attach — use `strategy.type: Recreate` unless the old pod fully terminates first.
+- Volumes are region-locked; combine with node affinity if you have multi-region node pools.
+
+**Shared storage across replicas / components (RWX)** — DO block storage does NOT support this. Options:
+
+1. **DO Spaces (S3-compatible)** — application-level, no PVC. Best fit for uploads, media, backups.
+2. **Self-hosted NFS server** — expose it via `persistentVolumes:` with `nfs:`.
+3. **Cluster storage add-ons** — install [Longhorn](https://longhorn.io/) or Rook-Ceph on top of DO block storage to get RWX.
+
+**NFS example on DO** (assumes an NFS server running in the cluster or a Droplet):
+
+```yaml
+persistentVolumes:
+  - name: uploads-nfs
+    capacity: 50Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: ""
+    reclaimPolicy: Retain
+    nfs:
+      server: 10.10.0.5       # private VPC IP of the NFS server
+      path: /exports/uploads
+
+persistentVolumeClaims:
+  - name: uploads
+    size: 50Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: ""
+    volumeName: uploads-nfs
+
+components:
+  web:
+    replicas: 3
+    persistence:
+      - name: uploads
+        existingClaim: uploads
+        mountPath: /var/www/uploads
+  worker:
+    replicas: 5
+    persistence:
+      - name: uploads
+        existingClaim: uploads
+        mountPath: /var/www/uploads
+```
+
+See [values-persistence.yaml](../../tests/app/values-persistence.yaml) for a full example covering all three patterns.
+
 ### Jobs and CronJobs
 
 Jobs are one-time executions:

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -302,6 +302,51 @@ Returns "true" if traefik, empty string otherwise.
 {{- end -}}
 
 {{/*
+PVC name for a component-level persistence entry.
+Auto-generated PVCs are named {release}-{component}-{persistenceName}.
+Usage: {{ include "app.componentPvcName" (dict "releaseName" $.Release.Name "componentName" $name "persistenceName" .name) }}
+*/}}
+{{- define "app.componentPvcName" -}}
+{{- printf "%s-%s-%s" .releaseName .componentName .persistenceName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Volume mounts for all persistence entries of a component.
+Usage: {{ include "app.persistenceVolumeMounts" $component.persistence | nindent 12 }}
+*/}}
+{{- define "app.persistenceVolumeMounts" -}}
+{{- range . }}
+- name: {{ .name }}
+  mountPath: {{ required "persistence[].mountPath is required" .mountPath }}
+  {{- if .subPath }}
+  subPath: {{ .subPath }}
+  {{- end }}
+  {{- if .readOnly }}
+  readOnly: {{ .readOnly }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Pod-level volumes for all persistence entries of a component.
+Each entry becomes a persistentVolumeClaim volume - either auto-created or existingClaim.
+Usage: {{ include "app.persistenceVolumes" (dict "releaseName" $.Release.Name "componentName" $componentName "persistence" $component.persistence) | nindent 8 }}
+*/}}
+{{- define "app.persistenceVolumes" -}}
+{{- $releaseName := .releaseName }}
+{{- $componentName := .componentName }}
+{{- range .persistence }}
+- name: {{ .name }}
+  persistentVolumeClaim:
+    {{- if .existingClaim }}
+    claimName: {{ .existingClaim }}
+    {{- else }}
+    claimName: {{ include "app.componentPvcName" (dict "releaseName" $releaseName "componentName" $componentName "persistenceName" .name) }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Pod affinity builder
 Usage: {{ include "app.affinity.pod" (dict "root" $ "componentName" $name "config" $config) }}
 */}}

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -54,9 +54,14 @@ spec:
           env:
             {{- toYaml .env | nindent 12 }}
           {{- end }}
-          {{- if $.Values.global.useDatabaseCert }}
+          {{- if or $.Values.global.useDatabaseCert $component.persistence }}
           volumeMounts:
+            {{- if $.Values.global.useDatabaseCert }}
             {{- include "app.databaseCertVolumeMount" $.Values.global | nindent 12 }}
+            {{- end }}
+            {{- if $component.persistence }}
+            {{- include "app.persistenceVolumeMounts" $component.persistence | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if .resources }}
           resources:
@@ -121,9 +126,14 @@ spec:
             periodSeconds: {{ $component.readinessProbe.periodSeconds | default 5 }}
           {{- end }}
           {{- end }}
-          {{- if $.Values.global.useDatabaseCert }}
+          {{- if or $.Values.global.useDatabaseCert $component.persistence }}
           volumeMounts:
+            {{- if $.Values.global.useDatabaseCert }}
             {{- include "app.databaseCertVolumeMount" $.Values.global | nindent 12 }}
+            {{- end }}
+            {{- if $component.persistence }}
+            {{- include "app.persistenceVolumeMounts" $component.persistence | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if $component.resources }}
           resources:
@@ -152,18 +162,28 @@ spec:
           env:
             {{- toYaml .env | nindent 12 }}
           {{- end }}
-          {{- if $.Values.global.useDatabaseCert }}
+          {{- if or $.Values.global.useDatabaseCert $component.persistence }}
           volumeMounts:
+            {{- if $.Values.global.useDatabaseCert }}
             {{- include "app.databaseCertVolumeMount" $.Values.global | nindent 12 }}
+            {{- end }}
+            {{- if $component.persistence }}
+            {{- include "app.persistenceVolumeMounts" $component.persistence | nindent 12 }}
+            {{- end }}
           {{- end }}
           {{- if .resources }}
           resources:
             {{- toYaml .resources | nindent 12 }}
           {{- end }}
         {{- end }}
-      {{- if $.Values.global.useDatabaseCert }}
+      {{- if or $.Values.global.useDatabaseCert $component.persistence }}
       volumes:
+        {{- if $.Values.global.useDatabaseCert }}
         {{- include "app.databaseCertVolume" $.Values.global | nindent 8 }}
+        {{- end }}
+        {{- if $component.persistence }}
+        {{- include "app.persistenceVolumes" (dict "releaseName" $.Release.Name "componentName" $componentName "persistence" $component.persistence) | nindent 8 }}
+        {{- end }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/app/templates/persistentvolumeclaims.yaml
+++ b/charts/app/templates/persistentvolumeclaims.yaml
@@ -1,0 +1,88 @@
+{{- /* Chart-level shared PersistentVolumeClaims */ -}}
+{{- range .Values.persistentVolumeClaims }}
+{{- if ne (.enabled | default true) false }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ required "persistentVolumeClaims[].name is required" .name }}
+  labels:
+    {{- include "app.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: pvc-{{ .name }}
+    {{- with include "app.customLabels" (dict "global" $.Values.global) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml (.accessModes | default (list "ReadWriteOnce")) | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ required "persistentVolumeClaims[].size is required" .size }}
+  {{- if hasKey . "storageClassName" }}
+  storageClassName: {{ .storageClassName | quote }}
+  {{- end }}
+  {{- if .volumeName }}
+  volumeName: {{ .volumeName }}
+  {{- end }}
+  {{- if .volumeMode }}
+  volumeMode: {{ .volumeMode }}
+  {{- end }}
+  {{- if .selector }}
+  selector:
+    {{- toYaml .selector | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{- /* Component-level auto-created PersistentVolumeClaims */ -}}
+{{- range $componentName, $component := .Values.components }}
+{{- if ne ($component.enabled | default true) false }}
+{{- range $component.persistence }}
+{{- if not .existingClaim }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "app.componentPvcName" (dict "releaseName" $.Release.Name "componentName" $componentName "persistenceName" .name) }}
+  labels:
+    {{- include "app.componentLabels" (dict "root" $ "componentName" $componentName) | nindent 4 }}
+    {{- with include "app.customLabels" (dict "global" $.Values.global "component" $component) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    {{- toYaml (.accessModes | default (list "ReadWriteOnce")) | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ required "components.*.persistence[].size is required (unless existingClaim is set)" .size }}
+  {{- if hasKey . "storageClassName" }}
+  storageClassName: {{ .storageClassName | quote }}
+  {{- end }}
+  {{- if .volumeName }}
+  volumeName: {{ .volumeName }}
+  {{- end }}
+  {{- if .volumeMode }}
+  volumeMode: {{ .volumeMode }}
+  {{- end }}
+  {{- if .selector }}
+  selector:
+    {{- toYaml .selector | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/app/templates/persistentvolumes.yaml
+++ b/charts/app/templates/persistentvolumes.yaml
@@ -1,0 +1,57 @@
+{{- range .Values.persistentVolumes }}
+{{- if ne (.enabled | default true) false }}
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ required "persistentVolumes[].name is required" .name }}
+  labels:
+    {{- include "app.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: pv-{{ .name }}
+    {{- with include "app.customLabels" (dict "global" $.Values.global) }}
+    {{- . | nindent 4 }}
+    {{- end }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  capacity:
+    storage: {{ required "persistentVolumes[].capacity is required" .capacity }}
+  accessModes:
+    {{- toYaml (.accessModes | default (list "ReadWriteOnce")) | nindent 4 }}
+  persistentVolumeReclaimPolicy: {{ .reclaimPolicy | default "Retain" }}
+  {{- if .storageClassName }}
+  storageClassName: {{ .storageClassName }}
+  {{- end }}
+  {{- if .volumeMode }}
+  volumeMode: {{ .volumeMode }}
+  {{- end }}
+  {{- if .mountOptions }}
+  mountOptions:
+    {{- toYaml .mountOptions | nindent 4 }}
+  {{- end }}
+  {{- if .claimRef }}
+  claimRef:
+    {{- toYaml .claimRef | nindent 4 }}
+  {{- end }}
+  {{- if .nfs }}
+  nfs:
+    {{- toYaml .nfs | nindent 4 }}
+  {{- else if .hostPath }}
+  hostPath:
+    {{- toYaml .hostPath | nindent 4 }}
+  {{- else if .csi }}
+  csi:
+    {{- toYaml .csi | nindent 4 }}
+  {{- else if .local }}
+  local:
+    {{- toYaml .local | nindent 4 }}
+  {{- else if .source }}
+  {{- toYaml .source | nindent 2 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -160,6 +160,16 @@ global:
 #           requiredSpreadBy: ["kubernetes.io/hostname"]
 #       initContainers: []
 #       additionalContainers: []
+#       persistence:                 # list of volumes to mount
+#         - name: cache              # auto-created PVC: {release}-{component}-cache
+#           size: 5Gi
+#           accessModes: [ReadWriteOnce]
+#           storageClassName: gp3
+#           mountPath: /var/cache
+#         - name: uploads
+#           existingClaim: shared-uploads   # reference chart-level or external PVC
+#           mountPath: /var/www/uploads
+#           readOnly: false
 #
 #     worker:
 #       enabled: true
@@ -213,3 +223,113 @@ jobs: []
 #           memory: "64Mi"
 
 cronJobs: []
+
+# =============================================================================
+# PERSISTENT VOLUMES (chart-level, static provisioning)
+# =============================================================================
+# Cluster-scoped PersistentVolumes. Use only when you need static provisioning
+# (existing NFS export, pre-provisioned disk, hostPath for local dev).
+# For most cases prefer dynamic provisioning via StorageClass on a PVC.
+#
+# Example - NFS export:
+#   persistentVolumes:
+#     - name: shared-nfs
+#       capacity: 100Gi
+#       accessModes: [ReadWriteMany]
+#       storageClassName: ""            # empty = static, no dynamic provisioner
+#       reclaimPolicy: Retain           # default: Retain
+#       nfs:
+#         server: nfs.example.com
+#         path: /exports/shared
+#
+# Example - hostPath (local dev only):
+#   persistentVolumes:
+#     - name: local-data
+#       capacity: 10Gi
+#       accessModes: [ReadWriteOnce]
+#       hostPath:
+#         path: /data/local
+#
+# Example - fully custom source (CSI, iSCSI, etc):
+#   persistentVolumes:
+#     - name: csi-vol
+#       capacity: 50Gi
+#       accessModes: [ReadWriteOnce]
+#       csi:
+#         driver: ebs.csi.aws.com
+#         volumeHandle: vol-abc123
+
+persistentVolumes: []
+
+# =============================================================================
+# PERSISTENT VOLUME CLAIMS (chart-level, shared between components)
+# =============================================================================
+# Use for storage that multiple components need to share (RWX) or when you
+# want a PVC that is decoupled from a single component's lifecycle.
+# Reference from a component via `existingClaim: <name>`.
+#
+# Example - shared uploads directory across web and worker:
+#   persistentVolumeClaims:
+#     - name: shared-uploads
+#       size: 20Gi
+#       accessModes: [ReadWriteMany]
+#       storageClassName: efs-sc
+#
+#   components:
+#     web:
+#       persistence:
+#         - name: uploads
+#           existingClaim: shared-uploads
+#           mountPath: /var/www/uploads
+#     worker:
+#       persistence:
+#         - name: uploads
+#           existingClaim: shared-uploads
+#           mountPath: /var/www/uploads
+#
+# Example - bind to a specific static PV:
+#   persistentVolumeClaims:
+#     - name: nfs-claim
+#       size: 100Gi
+#       accessModes: [ReadWriteMany]
+#       storageClassName: ""            # must match the PV
+#       volumeName: shared-nfs          # bind explicitly to PV `shared-nfs`
+
+persistentVolumeClaims: []
+
+# =============================================================================
+# COMPONENT PERSISTENCE
+# =============================================================================
+# Component-level `persistence` is a list of volume mounts. Each entry either
+# auto-creates a PVC (default) or references an existing one via `existingClaim`.
+# Auto-created PVCs are named `{release}-{component}-{persistenceName}`.
+#
+# Example - per-component private storage (auto-created PVC):
+#   components:
+#     web:
+#       persistence:
+#         - name: cache
+#           size: 5Gi
+#           accessModes: [ReadWriteOnce]
+#           storageClassName: gp3
+#           mountPath: /var/cache
+#
+# Example - mount shared chart-level PVC:
+#   components:
+#     web:
+#       persistence:
+#         - name: uploads
+#           existingClaim: shared-uploads
+#           mountPath: /var/www/uploads
+#
+# Example - mount PVC that was created outside the chart:
+#   components:
+#     web:
+#       persistence:
+#         - name: legacy-data
+#           existingClaim: pre-existing-pvc
+#           mountPath: /data
+#           readOnly: true
+#           subPath: subdir
+#
+# Volumes are mounted into main container, initContainers, and additionalContainers.

--- a/tests/app/values-full.yaml
+++ b/tests/app/values-full.yaml
@@ -17,6 +17,12 @@ global:
     podAntiAffinity:
       preferredSpreadBy: ["kubernetes.io/hostname"]
 
+persistentVolumeClaims:
+  - name: shared-uploads
+    size: 20Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: efs-sc
+
 components:
   web:
     enabled: true
@@ -91,6 +97,15 @@ components:
           requests:
             cpu: "50m"
             memory: "64Mi"
+    persistence:
+      - name: cache
+        size: 5Gi
+        accessModes: [ReadWriteOnce]
+        storageClassName: gp3
+        mountPath: /var/cache
+      - name: uploads
+        existingClaim: shared-uploads
+        mountPath: /var/www/uploads
 
   worker:
     enabled: true

--- a/tests/app/values-persistence.yaml
+++ b/tests/app/values-persistence.yaml
@@ -1,0 +1,118 @@
+---
+# Persistence test values for app chart
+# Demonstrates:
+# - Static PersistentVolumes (NFS + hostPath + CSI)
+# - Chart-level shared PersistentVolumeClaims
+# - Component-level auto-created PVCs
+# - Reference to existing (external) PVCs
+# - Mount into initContainers and sidecars
+
+global:
+  image: "myapp:v1.0.0"
+
+# Static PVs (rare - use only for pre-provisioned storage)
+persistentVolumes:
+  - name: shared-nfs
+    capacity: 100Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: ""
+    reclaimPolicy: Retain
+    nfs:
+      server: nfs.example.com
+      path: /exports/shared
+
+  - name: local-dev-data
+    capacity: 5Gi
+    accessModes: [ReadWriteOnce]
+    reclaimPolicy: Delete
+    hostPath:
+      path: /data/dev
+
+  - name: csi-preprovisioned
+    capacity: 50Gi
+    accessModes: [ReadWriteOnce]
+    storageClassName: gp3
+    csi:
+      driver: ebs.csi.aws.com
+      volumeHandle: vol-0123456789abcdef
+
+# Chart-level shared PVCs (referenced by multiple components)
+persistentVolumeClaims:
+  - name: shared-uploads
+    size: 20Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: efs-sc
+    labels:
+      backup: daily
+
+  - name: nfs-bound
+    size: 100Gi
+    accessModes: [ReadWriteMany]
+    storageClassName: ""
+    volumeName: shared-nfs
+
+components:
+  web:
+    replicas: 2
+    containerPort: 80
+    persistence:
+      # Auto-created PVC (component-private cache)
+      - name: cache
+        size: 5Gi
+        accessModes: [ReadWriteOnce]
+        storageClassName: gp3
+        mountPath: /var/cache
+      # Shared PVC from chart-level
+      - name: uploads
+        existingClaim: shared-uploads
+        mountPath: /var/www/uploads
+      # External PVC created outside the chart, read-only + subPath
+      - name: assets
+        existingClaim: external-assets
+        mountPath: /var/www/assets
+        readOnly: true
+        subPath: production
+    initContainers:
+      - name: chown-uploads
+        image: "busybox:latest"
+        command: "chown -R www-data:www-data /var/www/uploads"
+    additionalContainers:
+      - name: log-shipper
+        image: "fluent/fluent-bit:latest"
+        port: 2020
+
+  worker:
+    replicas: 3
+    command: "php artisan queue:work"
+    persistence:
+      # Same shared uploads volume as web
+      - name: uploads
+        existingClaim: shared-uploads
+        mountPath: /var/www/uploads
+
+  metrics:
+    replicas: 1
+    containerPort: 9090
+    persistence:
+      # Bind to a specific static PV
+      - name: nfs
+        existingClaim: nfs-bound
+        mountPath: /nfs
+
+  # Component without persistence still works
+  scheduler:
+    replicas: 1
+    command: "php artisan schedule:work"
+
+  # DigitalOcean pattern: RWO block storage + Recreate strategy
+  do-web:
+    replicas: 1
+    strategy:
+      type: Recreate
+    containerPort: 80
+    persistence:
+      - name: data
+        size: 10Gi
+        accessModes: [ReadWriteOnce]
+        storageClassName: do-block-storage
+        mountPath: /data


### PR DESCRIPTION
Adds three ways to use persistent storage in the app chart:
- chart-level static PersistentVolumes (nfs, hostPath, csi, local)
- chart-level shared PersistentVolumeClaims (referenced by multiple components)
- per-component `persistence` list that auto-creates PVCs or mounts existingClaim

Volumes are mounted into main container, initContainers, and additionalContainers. Includes docs (with DigitalOcean/DOKS notes on RWO limits and NFS workarounds) and a dedicated tests/app/values-persistence.yaml covering all patterns.