### PR TITLE
feat(app,n8n): add pod/container securityContext and args support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ template-app-persistence:
 	rm -rf .build/app
 	helm template test-app-persistence charts/app --output-dir=.build -f tests/app/values-persistence.yaml --debug
 
+template-app-security:
+	rm -rf .build/app
+	helm template test-app-security charts/app --output-dir=.build -f tests/app/values-security.yaml --debug
+
 template-metabase:
 	rm -rf .build/metabase
 	helm template test-metabase charts/metabase --output-dir=.build --debug
@@ -38,6 +42,10 @@ template-n8n-persistence:
 	rm -rf .build/n8n
 	helm template test-n8n-persistence charts/n8n --output-dir=.build -f tests/n8n/values-persistence.yaml --debug
 
+template-n8n-security:
+	rm -rf .build/n8n
+	helm template test-n8n-security charts/n8n --output-dir=.build -f tests/n8n/values-security.yaml --debug
+
 template-rbac:
 	rm -rf .build/rbac
 	helm template test-user charts/rbac --output-dir=.build -f tests/rbac/values.yaml --debug
@@ -52,6 +60,7 @@ helm-template:
 	make template-app
 	make template-app-affinity
 	make template-app-persistence
+	make template-app-security
 	make template-metabase
 	make template-adminer
 	make template-rbac

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v2
 description: Helm Chart for multi-component application deployments
 name: app
-version: 1.8.0
+version: 1.9.0
 appVersion: "1.0.0"

--- a/charts/app/README.md
+++ b/charts/app/README.md
@@ -10,7 +10,7 @@ This is the recommended chart for deploying applications with multiple component
 - **Auto-service creation** - Services are automatically created when `containerPort` or `ingress.enabled` is defined
 - **Global defaults** - Set common values like `image` and `host` globally, with per-component overrides
 - **Pod scheduling control** - Node affinity, pod affinity, and pod anti-affinity with simplified shortcuts
-- **Security features** - IP whitelisting, security path filters, basic auth support
+- **Security features** - IP whitelisting, security path filters, basic auth support, pod/container `securityContext`
 - **Resource management** - Per-component resource limits, Pod Disruption Budgets
 - **Job support** - One-time jobs and scheduled cron jobs
 - **Ingress with TLS** - NGINX ingress with automatic TLS via cert-manager and Let's Encrypt
@@ -523,6 +523,125 @@ components:
         username: "admin"
         password: "secretpassword"
 ```
+
+### Pod & Container Security Context
+
+Set pod-level (`fsGroup`, `runAsUser`, `runAsGroup`, `runAsNonRoot`, …) and container-level (`capabilities`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation`, …) security context. Both support global defaults with component-level overrides (same pattern as affinity / securityPathFilter).
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `global.podSecurityContext` | Default pod-level securityContext for every component | `{}` |
+| `global.securityContext` | Default container-level securityContext for every container | `{}` |
+| `components.<name>.podSecurityContext` | Overrides `global.podSecurityContext`. Set to `null` to disable the inherited default | inherits global |
+| `components.<name>.securityContext` | Overrides `global.securityContext` on the main container | inherits global |
+| `initContainers[].securityContext` | Overrides `global.securityContext` on an init container | inherits global |
+| `additionalContainers[].securityContext` | Overrides `global.securityContext` on a sidecar container | inherits global |
+| `jobs[].securityContext` / `jobs[].podSecurityContext` | Same semantics for Jobs | inherits global |
+| `cronJobs[].securityContext` / `cronJobs[].podSecurityContext` | Same semantics for CronJobs | inherits global |
+
+**Example — Pod Security Standard "restricted" baseline for the whole release:**
+
+```yaml
+global:
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop: [ALL]
+
+components:
+  web:
+    # inherits global — no override needed
+```
+
+**Example — fix RWO PVC ownership with `fsGroup`:**
+
+On block-storage CSI drivers (DO, AWS EBS, GCP PD) a freshly-provisioned PVC is mounted as `root:root` (mode 755). Non-root containers can't write. Setting `fsGroup` tells the kubelet to recursively `chown` the volume to that GID at mount time — the standard fix, avoids initContainer chown hacks.
+
+```yaml
+components:
+  hermes:
+    image: nousresearch/hermes-agent
+    podSecurityContext:
+      fsGroup: 10000               # matches the image's runtime user GID
+    persistence:
+      - name: data
+        size: 10Gi
+        accessModes: [ReadWriteOnce]
+        storageClassName: do-block-storage
+        mountPath: /opt/data
+```
+
+**Example — an init container needs root to run `chown`, main container drops privileges:**
+
+```yaml
+components:
+  legacy:
+    image: legacy/app:1.0
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 1000
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+    initContainers:
+      - name: chown-legacy-data
+        image: busybox:1.36
+        command: "chown -R 1000:1000 /var/data"
+        # Override the inherited security context: this init needs to run as root.
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+          runAsNonRoot: false
+```
+
+**Disabling an inherited default** — set the field to `null` explicitly:
+
+```yaml
+global:
+  securityContext:
+    readOnlyRootFilesystem: true
+
+components:
+  needs-writable-rootfs:
+    securityContext: null          # opts out entirely
+```
+
+### Container Command & Args
+
+The chart supports three ways to control what a container runs:
+
+| Form | K8s field mapping | Effect on image ENTRYPOINT |
+|------|-------------------|----------------------------|
+| `command: "cmd with args"` (string) | `command: ['sh', '-c', "cmd with args"]` | Replaces ENTRYPOINT with a shell |
+| `command: [foo, bar]` (list) | `command: [foo, bar]` | Replaces ENTRYPOINT (no shell) |
+| `args: [foo, bar]` (list) | `args: [foo, bar]` | Keeps ENTRYPOINT, overrides CMD |
+
+**When to use which:**
+
+- **String `command:`** — legacy default. Convenient for `php artisan queue:work`-style commands where you want shell features (env expansion, `&&`, redirection). Wrapped in `sh -c "..."` so `ENTRYPOINT` is replaced.
+- **List `command:`** — when you want the exec form (no shell) but still fully replace `ENTRYPOINT`. Rarely needed.
+- **`args:`** — the right choice for images that already have a proper `ENTRYPOINT` you want to keep: s6-overlay, tini, dumb-init, or any wrapper script that sets up the environment before starting the app. Overrides only `CMD`, so the image's init sequence still runs.
+
+**Example — image with s6-overlay ENTRYPOINT that must run before the app command:**
+
+```yaml
+components:
+  hermes:
+    image: nousresearch/hermes-agent
+    # Wrong: `command: "gateway run"` would replace /init (s6-overlay), skipping
+    # ownership fix hooks and losing the supervision tree.
+    # Right: keep /init, only override CMD.
+    args: [gateway, run]
+```
+
+Fields available on every container spec (main / init / additional / jobs / cronJobs): `command` (string or list), `args` (list), `securityContext`.
 
 ## Advanced Features
 

--- a/charts/app/templates/_helpers.tpl
+++ b/charts/app/templates/_helpers.tpl
@@ -292,6 +292,75 @@ Returns the resolved securityPathFilter config as YAML, or empty string if disab
 {{- end }}
 
 {{/*
+Pod-level securityContext resolver.
+Component-level `podSecurityContext` overrides `global.podSecurityContext`.
+An explicit null on the component disables the inherited global value.
+Usage: {{ include "app.podSecurityContext" (dict "component" $component "global" $.Values.global) }}
+Returns YAML of the merged/chosen securityContext, or empty string when nothing applies.
+*/}}
+{{- define "app.podSecurityContext" -}}
+{{- $ctx := dict }}
+{{- if .global.podSecurityContext }}
+{{- $ctx = .global.podSecurityContext }}
+{{- end }}
+{{- if hasKey .component "podSecurityContext" }}
+{{- if .component.podSecurityContext }}
+{{- $ctx = .component.podSecurityContext }}
+{{- else }}
+{{- $ctx = dict }}
+{{- end }}
+{{- end }}
+{{- if $ctx }}
+{{- toYaml $ctx }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container-level securityContext resolver.
+Per-container `securityContext` overrides `global.securityContext`.
+An explicit null on the container disables the inherited global value.
+Usage: {{ include "app.securityContext" (dict "container" $container "global" $.Values.global) }}
+Where $container is a component (main), initContainer, additionalContainer, job or cronJob entry.
+Returns YAML of the merged/chosen securityContext, or empty string when nothing applies.
+*/}}
+{{- define "app.securityContext" -}}
+{{- $ctx := dict }}
+{{- if .global.securityContext }}
+{{- $ctx = .global.securityContext }}
+{{- end }}
+{{- if hasKey .container "securityContext" }}
+{{- if .container.securityContext }}
+{{- $ctx = .container.securityContext }}
+{{- else }}
+{{- $ctx = dict }}
+{{- end }}
+{{- end }}
+{{- if $ctx }}
+{{- toYaml $ctx }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container command renderer.
+Backward-compatible with the existing string form (wrapped in `sh -c "..."`),
+plus a new list form that is passed straight through as a K8s command array
+(does NOT replace ENTRYPOINT via a shell). Use the list form together with
+`args:` when the container image already has a proper ENTRYPOINT (s6-overlay,
+tini, wrapper scripts, etc.) and you only want to override the CMD.
+Usage: {{ include "app.command" $cmd | nindent 12 }}
+*/}}
+{{- define "app.command" -}}
+{{- if kindIs "slice" . }}
+command:
+{{- range . }}
+  - {{ . | quote }}
+{{- end }}
+{{- else }}
+command: ['sh', '-c', {{ . | quote }}]
+{{- end }}
+{{- end }}
+
+{{/*
 Check if ingress class is traefik
 Usage: {{ include "app.isTraefik" (dict "className" $component.ingress.className "globalClassName" $.Values.global.ingressClassName) }}
 Returns "true" if traefik, empty string otherwise.

--- a/charts/app/templates/cronjobs.yaml
+++ b/charts/app/templates/cronjobs.yaml
@@ -22,12 +22,24 @@ spec:
       backoffLimit: {{ .backoffLimit | default 3 }}
       template:
         spec:
+          {{- with include "app.podSecurityContext" (dict "component" . "global" $.Values.global) }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
           containers:
             {{- $cronJobImage := .image | default $.Values.global.image }}
             - name: {{ .name }}
               image: {{ required "cronJobs[].image or global.image is required" $cronJobImage }}
               imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
-              command: ['sh', '-c', {{ required "cronJobs[].command is required" .command | quote }}]
+              {{- with include "app.securityContext" (dict "container" . "global" $.Values.global) }}
+              securityContext:
+                {{- . | nindent 16 }}
+              {{- end }}
+              {{- include "app.command" (required "cronJobs[].command is required" .command) | nindent 14 }}
+              {{- with .args }}
+              args:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               {{- if .envFromSecret }}
               envFrom:
                 - secretRef:

--- a/charts/app/templates/deployment.yaml
+++ b/charts/app/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         {{- . | nindent 8 }}
         {{- end }}
     spec:
+      {{- with include "app.podSecurityContext" (dict "component" $component "global" $.Values.global) }}
+      securityContext:
+        {{- . | nindent 8 }}
+      {{- end }}
       {{- with include "app.affinity" (dict "root" $ "componentName" $componentName "component" $component) }}
       affinity:
         {{- . | nindent 8 }}
@@ -42,8 +46,16 @@ spec:
         - name: {{ .name }}
           image: {{ required "initContainer.image or global.image is required" $initImage }}
           imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.imagePullPolicy }}
+          {{- with include "app.securityContext" (dict "container" . "global" $.Values.global) }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .command }}
-          command: ['sh', '-c', {{ .command | quote }}]
+          {{- include "app.command" .command | nindent 10 }}
+          {{- end }}
+          {{- with .args }}
+          args:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .envFromSecret }}
           envFrom:
@@ -76,8 +88,16 @@ spec:
         - name: {{ $componentName }}
           image: {{ required (printf "components.%s.image or global.image is required" $componentName) $componentImage }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
+          {{- with include "app.securityContext" (dict "container" $component "global" $.Values.global) }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if $component.command }}
-          command: ['sh', '-c', {{ $component.command | quote }}]
+          {{- include "app.command" $component.command | nindent 10 }}
+          {{- end }}
+          {{- with $component.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if $component.containerPort }}
           ports:
@@ -144,8 +164,16 @@ spec:
         - name: {{ .name }}
           image: {{ required "additionalContainer.image is required" .image }}
           imagePullPolicy: {{ .imagePullPolicy | default $.Values.global.imagePullPolicy }}
+          {{- with include "app.securityContext" (dict "container" . "global" $.Values.global) }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
           {{- if .command }}
-          command: ['sh', '-c', {{ .command | quote }}]
+          {{- include "app.command" .command | nindent 10 }}
+          {{- end }}
+          {{- with .args }}
+          args:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .port }}
           ports:

--- a/charts/app/templates/jobs.yaml
+++ b/charts/app/templates/jobs.yaml
@@ -14,12 +14,24 @@ spec:
   backoffLimit: {{ .backoffLimit | default 3 }}
   template:
     spec:
+      {{- with include "app.podSecurityContext" (dict "component" . "global" $.Values.global) }}
+      securityContext:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
         {{- $jobImage := .image | default $.Values.global.image }}
         - name: {{ .name }}
           image: {{ required "jobs[].image or global.image is required" $jobImage }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
-          command: ['sh', '-c', {{ required "jobs[].command is required" .command | quote }}]
+          {{- with include "app.securityContext" (dict "container" . "global" $.Values.global) }}
+          securityContext:
+            {{- . | nindent 12 }}
+          {{- end }}
+          {{- include "app.command" (required "jobs[].command is required" .command) | nindent 10 }}
+          {{- with .args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .envFromSecret }}
           envFrom:
             - secretRef:

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -40,6 +40,27 @@ global:
   # Restart all pods on every deployment (adds random annotation)
   restartAfterRedeploy: false
 
+  # Pod-level security context - default for every component pod.
+  # Component-level `podSecurityContext` overrides this map (last-wins, not merged).
+  # Set component.podSecurityContext to null to disable the inherited default.
+  # Example:
+  #   podSecurityContext:
+  #     fsGroup: 1000              # PVC ownership fix on RWO volumes
+  #     runAsUser: 1000
+  #     runAsGroup: 1000
+  #     runAsNonRoot: true
+  podSecurityContext: {}
+
+  # Container-level security context - default for every container (main / init /
+  # additional / job / cronJob). Container-level override wins; null disables.
+  # Example (Pod Security Standard "restricted" baseline):
+  #   securityContext:
+  #     allowPrivilegeEscalation: false
+  #     readOnlyRootFilesystem: true
+  #     capabilities:
+  #       drop: [ALL]
+  securityContext: {}
+
   # Affinity rules for pod scheduling
   # Applied globally to all components unless overridden
   affinity:
@@ -95,7 +116,28 @@ global:
 #       image: "myapp-web:latest"
 #       replicas: 2
 #       containerPort: 80
+#       # command: null → uses the image's ENTRYPOINT/CMD unchanged.
+#       # String form is wrapped in `sh -c "..."` (kept for backward compat).
+#       # List form is passed through as a raw K8s `command:` array — the image
+#       # ENTRYPOINT is fully replaced (no shell), useful for images with exec-style
+#       # entrypoints. Combine with `args:` (list) to keep the image ENTRYPOINT and
+#       # only override CMD — the right choice for images with s6-overlay, tini, or
+#       # custom wrapper scripts (e.g. `args: [gateway, run]`).
 #       command: null
+#       args: []
+#       # Pod-level securityContext (fsGroup, runAsUser, runAsGroup, ...).
+#       # Overrides global.podSecurityContext; null disables the inherited default.
+#       podSecurityContext:
+#         fsGroup: 1000
+#         runAsNonRoot: true
+#       # Container-level securityContext for the main container. Overrides
+#       # global.securityContext; null disables. Init and additional containers
+#       # can each carry their own `securityContext` block.
+#       securityContext:
+#         allowPrivilegeEscalation: false
+#         readOnlyRootFilesystem: true
+#         capabilities:
+#           drop: [ALL]
 #       labels:
 #         app.example.com/scaling: "enabled"
 #         app.example.com/shutdown-outside-hours: "true"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -2,5 +2,5 @@
 apiVersion: v1
 description: Helm Chart for installing self-hosted n8n workflow automation tool
 name: n8n
-version: 1.2.0
+version: 1.3.0
 appVersion: "latest"

--- a/charts/n8n/README.md
+++ b/charts/n8n/README.md
@@ -217,6 +217,70 @@ The chart itself does **not** copy data from ephemeral storage into the new PVC 
 | `ingress.tlsSecretName` | Custom TLS secret name | `""` |
 | `ingress.whitelistSourceRange` | IP whitelist for access restriction | `null` |
 
+### Security Context
+
+Pod-level (`fsGroup`, `runAsUser`, `runAsGroup`, `runAsNonRoot`, …) and container-level (`capabilities`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation`, …) security context.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `podSecurityContext` | Pod-level securityContext (applies to the whole pod) | `{}` |
+| `securityContext` | Container-level securityContext (applies to the n8n container) | `{}` |
+
+**Example — fix RWO PVC ownership with `fsGroup`:**
+
+n8n runs as uid 1000 inside the image. On block-storage CSI (DO, AWS EBS, GCP PD) a freshly-provisioned PVC is mounted as `root:root` — the container can't write to `/home/node/.n8n` and fails on startup. Set `fsGroup: 1000` and the kubelet chowns the volume at mount time. Standard fix, no initContainer needed.
+
+```yaml
+persistence:
+  enabled: true
+  size: 20Gi
+  storageClassName: do-block-storage
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+```
+
+**Example — Pod Security Standard "restricted" baseline:**
+
+```yaml
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
+securityContext:
+  allowPrivilegeEscalation: false
+  # readOnlyRootFilesystem: n8n writes some caches under /home/node — keep false
+  # unless you separately mount emptyDir over the relevant paths.
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop: [ALL]
+```
+
+### Container Command & Args
+
+Override the container command or its arguments.
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `command` (string) | Wrapped in `sh -c "..."`. Replaces the image ENTRYPOINT with a shell. | `null` |
+| `command` (list) | Passed as raw K8s `command:` array. Replaces ENTRYPOINT, no shell. | `null` |
+| `args` (list) | Passed as K8s `args:`. **Keeps the image ENTRYPOINT** and overrides only CMD. | `null` |
+
+The n8n image has a proper ENTRYPOINT that sets up the runtime. Prefer `args:` if you only need to change the command passed to n8n — it preserves the image's init sequence.
+
+```yaml
+# Right — keeps ENTRYPOINT, only changes CMD:
+args: ["start", "--tunnel"]
+
+# Wrong — replaces ENTRYPOINT with a shell, skipping the image's init:
+command: "n8n start --tunnel"
+```
+
 ## Environment Configuration
 
 n8n supports extensive configuration through environment variables. Create a Kubernetes secret with your settings:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -24,10 +24,30 @@ spec:
       labels:
         app: {{ .Release.Name }}
     spec:
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: n8n
           image: {{ include "n8n.image" . }}
           imagePullPolicy: {{ include "n8n.imagePullPolicy" . }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.command }}
+          {{- if kindIs "slice" . }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- else }}
+          command: ['sh', '-c', {{ . | quote }}]
+          {{- end }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{ if .Values.envFromSecret }}
           envFrom:
             - secretRef:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -27,6 +27,38 @@ replicas: 1
 imagePullPolicy: null
 envFromSecret: null
 
+# Container command / args override.
+# - command as string → wrapped in `sh -c "..."` (replaces ENTRYPOINT with a shell)
+# - command as list   → passed as raw K8s command (replaces ENTRYPOINT, no shell)
+# - args              → passed as K8s args (keeps ENTRYPOINT, overrides only CMD)
+# n8n image has a proper ENTRYPOINT — prefer `args:` if you only need to change CMD.
+# Example:
+#   args: ["start", "--tunnel"]
+command: null
+args: null
+
+# Pod-level securityContext (fsGroup / runAsUser / runAsGroup / runAsNonRoot / ...).
+# n8n runs as uid 1000 (node) inside the image. When persistence is enabled on a
+# block-storage CSI (DO / AWS EBS / GCP PD), the freshly-provisioned PVC is mounted
+# as root:root — set `fsGroup: 1000` here so the kubelet chowns it at mount time
+# and n8n can write. Empty map = no securityContext set on the pod.
+# Example:
+#   podSecurityContext:
+#     fsGroup: 1000
+#     runAsUser: 1000
+#     runAsGroup: 1000
+#     runAsNonRoot: true
+podSecurityContext: {}
+
+# Container-level securityContext for the n8n container.
+# Example (Pod Security Standard "restricted" baseline):
+#   securityContext:
+#     allowPrivilegeEscalation: false
+#     readOnlyRootFilesystem: false     # n8n writes to /home/node/.n8n
+#     capabilities:
+#       drop: [ALL]
+securityContext: {}
+
 # Deployment strategy (optional). When persistence is enabled and this is
 # unset, defaults to Recreate to avoid ReadWriteOnce attach conflicts during
 # rolling updates. Set explicitly to override.

--- a/tests/app/values-full.yaml
+++ b/tests/app/values-full.yaml
@@ -13,6 +13,14 @@ global:
   labels:
     app.example.com/environment: "staging"
     app.example.com/team: "platform"
+  podSecurityContext:
+    fsGroup: 1000
+    runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
   affinity:
     podAntiAffinity:
       preferredSpreadBy: ["kubernetes.io/hostname"]
@@ -112,6 +120,13 @@ components:
     image: "myapp-worker:v1.0.0"
     replicas: 5
     command: "php artisan queue:work --queue=high,default"
+    # Component-level securityContext override (drops the capability drop from global
+    # while keeping the rest). Container-level override.
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: [ALL]
     labels:
       app.example.com/scaling: "aggressive"
     resources:

--- a/tests/app/values-security.yaml
+++ b/tests/app/values-security.yaml
@@ -1,0 +1,72 @@
+---
+# Security context + command/args test values.
+#
+# Demonstrates:
+#   - global.podSecurityContext + global.securityContext as defaults
+#   - component overrides (including null to disable inherited global)
+#   - per-initContainer / per-additionalContainer securityContext overrides
+#   - command as string (sh -c wrap, backward-compatible)
+#   - command as list (raw K8s command, ENTRYPOINT override without shell)
+#   - args (K8s CMD override; use with images that already have a proper ENTRYPOINT)
+
+global:
+  # Defaults applied to every pod / container unless a more specific override exists.
+  podSecurityContext:
+    fsGroup: 10000
+    runAsNonRoot: true
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop: [ALL]
+
+components:
+  # Inherits global pod + container securityContext.
+  # Demonstrates `args:` (list) — image ENTRYPOINT stays alive, only CMD is overridden.
+  # Typical use case: images with s6-overlay / tini / wrapper scripts.
+  hermes:
+    image: "nousresearch/hermes-agent"
+    args: [gateway, run]
+    podSecurityContext:
+      # Overrides global; merged fields not supported (last-wins for the whole map).
+      fsGroup: 10000
+      runAsUser: 10000
+      runAsGroup: 10000
+      runAsNonRoot: true
+    persistence:
+      - name: data
+        size: 10Gi
+        mountPath: /opt/data
+
+  # Uses the raw list-form command — passed straight through to K8s `command:`,
+  # bypasses the sh -c wrap. ENTRYPOINT of the image is fully replaced.
+  worker:
+    image: "myapp-worker:latest"
+    command: ["/usr/local/bin/worker", "--queue", "default,high"]
+
+  # Legacy string command form still works — wrapped in `sh -c "..."`.
+  # Backward compatibility with all existing values files.
+  scheduler:
+    image: "myapp-worker:latest"
+    command: "php artisan schedule:work"
+
+  # Component-level override disables the inherited global by passing null.
+  # Container-level securityContext also nulled; the pod runs with cluster defaults.
+  privileged-adapter:
+    image: "legacy/adapter:1.0"
+    podSecurityContext: null
+    securityContext: null
+    initContainers:
+      # Init container needs root to fix ownership on a freshly-mounted PVC.
+      # Overrides the inherited global securityContext with its own.
+      - name: chown-data
+        image: "busybox:1.36"
+        command: "chown -R 10000:10000 /var/data"
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+    additionalContainers:
+      - name: metrics
+        image: "prom/node-exporter:latest"
+        port: 9100
+        # Inherits global.securityContext (drop ALL caps, no priv escalation).

--- a/tests/n8n/values-security.yaml
+++ b/tests/n8n/values-security.yaml
@@ -1,0 +1,36 @@
+---
+# Security context + command/args test values for n8n chart.
+#
+# Demonstrates:
+#   - podSecurityContext (fsGroup fixes RWO PVC ownership on DO / EBS / GCP PD)
+#   - securityContext at container level (PSS restricted baseline)
+#   - args (list) — overrides only CMD, preserves the image's ENTRYPOINT
+
+image:
+  repository: docker.n8n.io/n8nio/n8n
+  tag: "latest"
+
+replicas: 1
+
+persistence:
+  enabled: true
+  size: 10Gi
+  accessModes: [ReadWriteOnce]
+  storageClassName: do-block-storage
+  mountPath: /home/node/.n8n
+
+podSecurityContext:
+  fsGroup: 1000
+  runAsUser: 1000
+  runAsGroup: 1000
+  runAsNonRoot: true
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: false
+  capabilities:
+    drop: [ALL]
+
+# Overrides only the CMD — image ENTRYPOINT (`tini -- /docker-entrypoint.sh`)
+# stays intact so runtime setup still happens before n8n starts.
+args: ["start", "--tunnel"]


### PR DESCRIPTION
Adds pod-level and container-level securityContext (with global defaults and component-level overrides, following the existing affinity / securityPathFilter override pattern) plus a proper args field that preserves the image ENTRYPOINT.

Motivation
- Pod Security Standards / OPA policies increasingly require explicit securityContext at the workload level. Charts had no way to set it.
- Running non-root containers with RWO PVCs (DO Block Storage, EBS, GCP PD) required workarounds — a chart-level fsGroup solves it directly and replaces the initContainer-chown hack.
- The chart wraps command: in `sh -c` which fully replaces ENTRYPOINT. Images with a proper init (s6-overlay, tini, wrapper scripts) break silently — permission errors, missing supervision, dropped runtime setup. `args:` overrides only CMD so ENTRYPOINT stays alive.

app chart (v1.8.0 → v1.9.0)
- global.podSecurityContext + global.securityContext defaults
- component-level podSecurityContext / securityContext override, null disables the inherited global (same semantics as affinity)
- per-initContainer and per-additionalContainer securityContext
- Same fields on jobs[] and cronJobs[]
- Container command now accepts a list (raw K8s command, no sh -c wrap) in addition to the existing string form (backward-compatible)
- New args: field on component / init / additional / jobs / cronJobs
- Helpers: app.podSecurityContext, app.securityContext, app.command

n8n chart (v1.2.0 → v1.3.0)
- podSecurityContext + securityContext values
- command (string or list) + args
- README section covering fsGroup for RWO PVC ownership, PSS restricted baseline, and args-vs-command guidance for the ENTRYPOINT-preserving image init

Tests
- tests/app/values-security.yaml — covers global defaults, component override, per-init override, args list, string+list command forms
- tests/n8n/values-security.yaml — covers persistence + PSS restricted baseline + args
- tests/app/values-full.yaml extended with securityContext coverage
- Makefile: template-app-security + template-n8n-security targets; template-app-security added to helm-template CI target

Docs
- charts/app/README.md — new "Pod & Container Security Context" and "Container Command & Args" sections with matrix, examples, and guidance on when to use args vs command
- charts/n8n/README.md — matching "Security Context" and "Container Command & Args" sections
- values.yaml files documented inline